### PR TITLE
Fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
 .cache
+.idea
 
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__
 .idea
 
 *.py[cod]
+
+*.egg-info

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # PyFME
 Python Flight Mechanics Engine
+
+## How to run the tests
+
+Install in editable mode and call `py.test`:
+
+    $ pip install -e .
+    $ py.test
  

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+from distutils.core import setup
+
+setup(
+    name="PyFME",
+    version="0.1.dev0",
+    packages=['pyfme'],
+    package_dir={'': 'src'},
+)


### PR DESCRIPTION
He añadido un `setup.py` mínimo para que el proyecto se pueda instalar. Las explicaciones están en el commit. Naturalmente habría que añadir descripción, etiquetas y demás, pero no hace falta para lo que quería demostrar. Nótese que no usa `setuptools` porque no hace falta si se instala usando `pip install -e .`. Los porqués de no usar setuptools... se explicarán en el curso post-avanzado :sweat_smile: 

Con estos cambios no hace falta archivo `__init__.py` en la carpeta de tests, con lo que se podría cerrar #12.